### PR TITLE
docs(diagrams): add architecture + component + UML diagrams; fix README rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ docs/ (original documentation preserved)
 ## SharePoint CSV Simulator Testing
 
 All dataset generators are covered by property-based tests (using Hypothesis) that verify:
+
 * Header and schema invariants
 * Role enforcement
 * Value ranges and edge cases
@@ -197,6 +198,12 @@ All prior architecture rationale, migration notes, and phase achievements remain
 
 - Architecture Overview (Mermaid): docs/architecture/diagrams/architecture-overview.md
 - Service Boundaries (Mermaid): docs/architecture/diagrams/service-boundaries.md
+ - Component: Collector — docs/architecture/diagrams/component-collector.md
+ - Component: Loader — docs/architecture/diagrams/component-loader.md
+ - Component: Aggregator — docs/architecture/diagrams/component-aggregator.md
+ - Component: Excel/HTML Generator — docs/architecture/diagrams/component-excel.md
+ - Component: API — docs/architecture/diagrams/component-api.md
+ - Component: Simulator — docs/architecture/diagrams/component-simulator.md
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -196,14 +196,14 @@ All prior architecture rationale, migration notes, and phase achievements remain
 
 ## Diagrams
 
-- Architecture Overview (Mermaid): docs/architecture/diagrams/architecture-overview.md
-- Service Boundaries (Mermaid): docs/architecture/diagrams/service-boundaries.md
- - Component: Collector — docs/architecture/diagrams/component-collector.md
- - Component: Loader — docs/architecture/diagrams/component-loader.md
- - Component: Aggregator — docs/architecture/diagrams/component-aggregator.md
- - Component: Excel/HTML Generator — docs/architecture/diagrams/component-excel.md
- - Component: API — docs/architecture/diagrams/component-api.md
- - Component: Simulator — docs/architecture/diagrams/component-simulator.md
+- [Architecture Overview (Mermaid)](docs/architecture/diagrams/architecture-overview.md)
+- [Service Boundaries (Mermaid)](docs/architecture/diagrams/service-boundaries.md)
+- [Component: Collector](docs/architecture/diagrams/component-collector.md)
+- [Component: Loader](docs/architecture/diagrams/component-loader.md)
+- [Component: Aggregator](docs/architecture/diagrams/component-aggregator.md)
+- [Component: Excel/HTML Generator](docs/architecture/diagrams/component-excel.md)
+- [Component: API](docs/architecture/diagrams/component-api.md)
+- [Component: Simulator](docs/architecture/diagrams/component-simulator.md)
 
 ### Architecture Overview (inline)
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,13 @@ All prior architecture rationale, migration notes, and phase achievements remain
 - [Component: API](docs/architecture/diagrams/component-api.md)
 - [Component: Simulator](docs/architecture/diagrams/component-simulator.md)
 
+### UML (Mermaid)
+
+- [UML Class: Foundation](docs/architecture/diagrams/uml/class-foundation.md)
+- [UML Sequence: Ingest Flow](docs/architecture/diagrams/uml/sequence-ingest.md)
+- [UML Sequence: Generate Hourly Report](docs/architecture/diagrams/uml/sequence-generate-hourly.md)
+- [UML Sequence: Simulator Generate](docs/architecture/diagrams/uml/sequence-simulator-generate.md)
+
 ### Architecture Overview (inline)
 
 ```mermaid

--- a/README.md
+++ b/README.md
@@ -5,16 +5,17 @@
 This repository has been reset to a **minimal, configurable reporting foundation** focused on:
 
 * Ingesting SharePoint‑exported CSV drops
+
 # Charlie Reporting (Lean Foundation Restart)
 
 [![Quality Gate](https://github.com/jwardwell7077/charlie-reporting/actions/workflows/quality-gate.yml/badge.svg)](https://github.com/jwardwell7077/charlie-reporting/actions/workflows/quality-gate.yml)
 
 This repository has been reset to a minimal, configurable reporting foundation focused on:
 
-- Ingesting SharePoint‑exported CSV drops
-- Loading data into a lightweight local SQLite store
-- Generating hourly and quad‑daily Excel/HTML outputs
-- Preparing for later email distribution and real SharePoint / Graph API integration
+* Ingesting SharePoint‑exported CSV drops
+* Loading data into a lightweight local SQLite store
+* Generating hourly and quad‑daily Excel/HTML outputs
+* Preparing for later email distribution and real SharePoint / Graph API integration
 
 Historic microservice code has been pruned (kept in prior Git history). Documentation and configuration files remain for reference/value.
 
@@ -43,10 +44,10 @@ The repository includes a lightweight SharePoint CSV simulator (deterministic te
 
 All dataset generators are covered by property-based tests (using Hypothesis) that verify:
 
-- Header and schema invariants
-- Role enforcement
-- Value ranges and edge cases
-- Row count clamping
+* Header and schema invariants
+* Role enforcement
+* Value ranges and edge cases
+* Row count clamping
 
 Edge-case and regression tests are included for all error branches and invariants. See `tests/sim/` for details.
 
@@ -54,10 +55,10 @@ Edge-case and regression tests are included for all error branches and invariant
 
 The simulator is mounted at `/sim` in the main API. Example endpoints:
 
-- `POST /sim/generate?types=ACQ,Productivity&rows=25` — generate one or more datasets
-- `GET /sim/files` — list generated files
-- `GET /sim/download/{filename}` — download CSV
-- `POST /sim/reset` — clear generated files
+* `POST /sim/generate?types=ACQ,Productivity&rows=25` — generate one or more datasets
+* `GET /sim/files` — list generated files
+* `GET /sim/download/{filename}` — download CSV
+* `POST /sim/reset` — clear generated files
 
 Simulator configuration: edit `config/sharepoint_sim.toml`:
 
@@ -74,11 +75,11 @@ Files are named `<DATASET>__YYYY-MM-DD_HHMM.csv` (5‑minute UTC rounding) and r
 
 Active runtime configuration now lives in `config/settings.toml` (see populated example in repo). Key sections:
 
-- `[schedules]` – hourly interval + explicit quad‑daily times
-- `[data_sources]` / `[[data_sources.sources]]` – list of named CSV patterns to ingest
-- `[collector]` – input (SharePoint dump), staging, archive directories
-- `[report]` – output directory, workbook name, per‑source column whitelists
-- `[email]` – (placeholder) future outbound email metadata
+* `[schedules]` – hourly interval + explicit quad‑daily times
+* `[data_sources]` / `[[data_sources.sources]]` – list of named CSV patterns to ingest
+* `[collector]` – input (SharePoint dump), staging, archive directories
+* `[report]` – output directory, workbook name, per‑source column whitelists
+* `[email]` – (placeholder) future outbound email metadata
 
 Legacy `config/config.toml` provided email folder filters and per‑file column selections. These have been mapped forward:
 
@@ -132,9 +133,9 @@ We adhere to a core design principle: Minimal Entry / Minimal Exit.
 
 Examples:
 
-- `Roster` self-loads on construction (optional `from_csv` classmethod) — removed former `load_roster()` wrapper.
-- Dataset generators expose a single `build()` path instead of scattered helper functions.
-- Service orchestration keeps state explicit (roster, RNG, storage) with no hidden globals.
+* `Roster` self-loads on construction (optional `from_csv` classmethod) — removed former `load_roster()` wrapper.
+* Dataset generators expose a single `build()` path instead of scattered helper functions.
+* Service orchestration keeps state explicit (roster, RNG, storage) with no hidden globals.
 
 See `docs/development_principles.md` for rationale, review checklist, and contribution guidelines.
 
@@ -163,21 +164,21 @@ All prior architecture rationale, migration notes, and phase achievements remain
 
 ## Diagrams
 
-- [Architecture Overview (Mermaid)](docs/architecture/diagrams/architecture-overview.md)
-- [Service Boundaries (Mermaid)](docs/architecture/diagrams/service-boundaries.md)
-- [Component: Collector](docs/architecture/diagrams/component-collector.md)
-- [Component: Loader](docs/architecture/diagrams/component-loader.md)
-- [Component: Aggregator](docs/architecture/diagrams/component-aggregator.md)
-- [Component: Excel/HTML Generator](docs/architecture/diagrams/component-excel.md)
-- [Component: API](docs/architecture/diagrams/component-api.md)
-- [Component: Simulator](docs/architecture/diagrams/component-simulator.md)
+* [Architecture Overview (Mermaid)](docs/architecture/diagrams/architecture-overview.md)
+* [Service Boundaries (Mermaid)](docs/architecture/diagrams/service-boundaries.md)
+* [Component: Collector](docs/architecture/diagrams/component-collector.md)
+* [Component: Loader](docs/architecture/diagrams/component-loader.md)
+* [Component: Aggregator](docs/architecture/diagrams/component-aggregator.md)
+* [Component: Excel/HTML Generator](docs/architecture/diagrams/component-excel.md)
+* [Component: API](docs/architecture/diagrams/component-api.md)
+* [Component: Simulator](docs/architecture/diagrams/component-simulator.md)
 
 ### UML (Mermaid)
 
-- [UML Class: Foundation](docs/architecture/diagrams/uml/class-foundation.md)
-- [UML Sequence: Ingest Flow](docs/architecture/diagrams/uml/sequence-ingest.md)
-- [UML Sequence: Generate Hourly Report](docs/architecture/diagrams/uml/sequence-generate-hourly.md)
-- [UML Sequence: Simulator Generate](docs/architecture/diagrams/uml/sequence-simulator-generate.md)
+* [UML Class: Foundation](docs/architecture/diagrams/uml/class-foundation.md)
+* [UML Sequence: Ingest Flow](docs/architecture/diagrams/uml/sequence-ingest.md)
+* [UML Sequence: Generate Hourly Report](docs/architecture/diagrams/uml/sequence-generate-hourly.md)
+* [UML Sequence: Simulator Generate](docs/architecture/diagrams/uml/sequence-simulator-generate.md)
 
 ### Architecture Overview (inline)
 
@@ -233,4 +234,3 @@ Proprietary / internal (adjust as needed). Add explicit license if distribution 
 ---
 
 For deeper architectural description see `foundation/README.md`.
-

--- a/README.md
+++ b/README.md
@@ -2,14 +2,21 @@
 
 [![Quality Gate](https://github.com/jwardwell7077/charlie-reporting/actions/workflows/quality-gate.yml/badge.svg)](https://github.com/jwardwell7077/charlie-reporting/actions/workflows/quality-gate.yml)
 
-This repository is a minimal, configurable reporting foundation focused on:
+This repository has been reset to a **minimal, configurable reporting foundation** focused on:
 
 * Ingesting SharePoint‑exported CSV drops
-* Loading data into a lightweight local SQLite store
-* Generating hourly and quad‑daily Excel/HTML outputs
-* Preparing for later email distribution and Graph API integration
+# Charlie Reporting (Lean Foundation Restart)
 
-Historic microservice code was pruned (kept in prior Git history). Documentation and configuration files remain for reference/value.
+[![Quality Gate](https://github.com/jwardwell7077/charlie-reporting/actions/workflows/quality-gate.yml/badge.svg)](https://github.com/jwardwell7077/charlie-reporting/actions/workflows/quality-gate.yml)
+
+This repository has been reset to a minimal, configurable reporting foundation focused on:
+
+- Ingesting SharePoint‑exported CSV drops
+- Loading data into a lightweight local SQLite store
+- Generating hourly and quad‑daily Excel/HTML outputs
+- Preparing for later email distribution and real SharePoint / Graph API integration
+
+Historic microservice code has been pruned (kept in prior Git history). Documentation and configuration files remain for reference/value.
 
 ## Current Core
 
@@ -30,25 +37,27 @@ data/ (sample CSVs kept)
 docs/ (original documentation preserved)
 ```
 
+The repository includes a lightweight SharePoint CSV simulator (deterministic test data generator) under `sharepoint_sim` with FastAPI endpoints mounted at `/sim`.
+
 ## SharePoint CSV Simulator Testing
 
 All dataset generators are covered by property-based tests (using Hypothesis) that verify:
 
-* Header and schema invariants
-* Role enforcement
-* Value ranges and edge cases
-* Row count clamping
+- Header and schema invariants
+- Role enforcement
+- Value ranges and edge cases
+- Row count clamping
 
 Edge-case and regression tests are included for all error branches and invariants. See `tests/sim/` for details.
 
 ## SharePoint CSV Simulator Usage
 
-Simulator is mounted at `/sim` in the main API. Example endpoints:
+The simulator is mounted at `/sim` in the main API. Example endpoints:
 
-* `POST /sim/generate?types=ACQ,Productivity&rows=25` — generate one or more datasets
-* `GET /sim/files` — list generated files
-* `GET /sim/download/{filename}` — download CSV
-* `POST /sim/reset` — clear generated files
+- `POST /sim/generate?types=ACQ,Productivity&rows=25` — generate one or more datasets
+- `GET /sim/files` — list generated files
+- `GET /sim/download/{filename}` — download CSV
+- `POST /sim/reset` — clear generated files
 
 Simulator configuration: edit `config/sharepoint_sim.toml`:
 
@@ -63,15 +72,15 @@ Files are named `<DATASET>__YYYY-MM-DD_HHMM.csv` (5‑minute UTC rounding) and r
 
 ## Configuration Overview
 
-Active runtime configuration lives in `config/settings.toml` (see populated example). Key sections:
+Active runtime configuration now lives in `config/settings.toml` (see populated example in repo). Key sections:
 
-* `[schedules]` – hourly interval + explicit quad‑daily times
-* `[data_sources]` / `[[data_sources.sources]]` – list of named CSV patterns to ingest
-* `[collector]` – input (SharePoint dump), staging, archive directories
-* `[report]` – output directory, workbook name, per‑source column whitelists
-* `[email]` – (placeholder) future outbound email metadata
+- `[schedules]` – hourly interval + explicit quad‑daily times
+- `[data_sources]` / `[[data_sources.sources]]` – list of named CSV patterns to ingest
+- `[collector]` – input (SharePoint dump), staging, archive directories
+- `[report]` – output directory, workbook name, per‑source column whitelists
+- `[email]` – (placeholder) future outbound email metadata
 
-Legacy `config/config.toml` folder filters and per‑file column selections are mapped forward:
+Legacy `config/config.toml` provided email folder filters and per‑file column selections. These have been mapped forward:
 
 | Legacy Section | New Mapping |
 |----------------|-------------|
@@ -101,7 +110,7 @@ curl -X POST http://localhost:8000/generate/hourly
 
 ## Quality Gate and Tooling
 
-Strict gate (local & CI): Ruff (lint/format), mypy (strict), Pyright (strict), pydoclint, interrogate (100% doc coverage), pytest (100% line coverage enforced). Test files are included in Ruff, mypy, and Pyright runs.
+Strict gate (local and CI): Ruff (lint/format), mypy (strict), Pyright (strict), pydoclint, interrogate (100% doc coverage), pytest (100% line coverage enforced). Test files are included in Ruff, mypy, and Pyright runs to keep helper code quality aligned with production modules.
 
 Run locally:
 
@@ -109,11 +118,11 @@ Run locally:
 scripts/quality_gate.sh
 ```
 
-Pre-commit (`pre-commit install`) runs Ruff, mypy subset, Pyright, quick pytest smoke.
+Pre-commit (`pre-commit install`) runs Ruff, mypy subset, Pyright, and a quick pytest smoke.
 
 ## CI
 
-Workflow `.github/workflows/quality-gate.yml` enforces the gate on pushes/PRs to `main` and `main-foundation`.
+Workflow `.github/workflows/quality-gate.yml` enforces the gate on pushes and PRs to `main` and `main-foundation`.
 
 ## Development Principles
 
@@ -123,27 +132,52 @@ We adhere to a core design principle: Minimal Entry / Minimal Exit.
 
 Examples:
 
-* `Roster` self-loads on construction (optional `from_csv` classmethod) — removed former `load_roster()` wrapper.
-* Dataset generators expose a single `build()` path instead of scattered helpers.
-* Service orchestration keeps state explicit (roster, RNG, storage) with no hidden globals.
+- `Roster` self-loads on construction (optional `from_csv` classmethod) — removed former `load_roster()` wrapper.
+- Dataset generators expose a single `build()` path instead of scattered helper functions.
+- Service orchestration keeps state explicit (roster, RNG, storage) with no hidden globals.
+
+See `docs/development_principles.md` for rationale, review checklist, and contribution guidelines.
+
+## Baseline Tag
+
+Tag the stabilized foundation:
+
+```bash
+git checkout main-foundation
+git tag -a v0.2.0-foundation -m "Foundation quality gate baseline"
+git push origin v0.2.0-foundation
+```
+
+## Roadmap (Near Term)
+
+1. Expand tests (failure paths, loader idempotency, error cases)
+2. Add scheduler (APScheduler) hourly and quad‑daily triggers
+3. Implement email packaging (HTML inline and attachment)
+4. Extend loader (additional sources, ingestion_log semantics)
+5. Structured logging and metrics stub
+6. Replace stub with Graph API SharePoint ingestion pipeline
+
+## Contributing / Historical Docs
+
+All prior architecture rationale, migration notes, and phase achievements remain under `docs/`.
 
 ## Diagrams
 
-* [Architecture Overview (Mermaid)](docs/architecture/diagrams/architecture-overview.md)
-* [Service Boundaries (Mermaid)](docs/architecture/diagrams/service-boundaries.md)
-* [Component: Collector](docs/architecture/diagrams/component-collector.md)
-* [Component: Loader](docs/architecture/diagrams/component-loader.md)
-* [Component: Aggregator](docs/architecture/diagrams/component-aggregator.md)
-* [Component: Excel/HTML Generator](docs/architecture/diagrams/component-excel.md)
-* [Component: API](docs/architecture/diagrams/component-api.md)
-* [Component: Simulator](docs/architecture/diagrams/component-simulator.md)
+- [Architecture Overview (Mermaid)](docs/architecture/diagrams/architecture-overview.md)
+- [Service Boundaries (Mermaid)](docs/architecture/diagrams/service-boundaries.md)
+- [Component: Collector](docs/architecture/diagrams/component-collector.md)
+- [Component: Loader](docs/architecture/diagrams/component-loader.md)
+- [Component: Aggregator](docs/architecture/diagrams/component-aggregator.md)
+- [Component: Excel/HTML Generator](docs/architecture/diagrams/component-excel.md)
+- [Component: API](docs/architecture/diagrams/component-api.md)
+- [Component: Simulator](docs/architecture/diagrams/component-simulator.md)
 
 ### UML (Mermaid)
 
-* [UML Class: Foundation](docs/architecture/diagrams/uml/class-foundation.md)
-* [UML Sequence: Ingest Flow](docs/architecture/diagrams/uml/sequence-ingest.md)
-* [UML Sequence: Generate Hourly Report](docs/architecture/diagrams/uml/sequence-generate-hourly.md)
-* [UML Sequence: Simulator Generate](docs/architecture/diagrams/uml/sequence-simulator-generate.md)
+- [UML Class: Foundation](docs/architecture/diagrams/uml/class-foundation.md)
+- [UML Sequence: Ingest Flow](docs/architecture/diagrams/uml/sequence-ingest.md)
+- [UML Sequence: Generate Hourly Report](docs/architecture/diagrams/uml/sequence-generate-hourly.md)
+- [UML Sequence: Simulator Generate](docs/architecture/diagrams/uml/sequence-simulator-generate.md)
 
 ### Architecture Overview (inline)
 
@@ -194,7 +228,9 @@ flowchart LR
 
 ## License
 
-Proprietary/internal (adjust as needed). Add explicit license if distribution scope changes.
+Proprietary / internal (adjust as needed). Add explicit license if distribution scope changes.
 
 ---
+
 For deeper architectural description see `foundation/README.md`.
+

--- a/README.md
+++ b/README.md
@@ -193,6 +193,11 @@ git push origin v0.2.0-foundation
 
 All prior architecture rationale, migration notes, and phase achievements remain under `docs/`.
 
+## Diagrams
+
+- Architecture Overview (Mermaid): docs/architecture/diagrams/architecture-overview.md
+- Service Boundaries (Mermaid): docs/architecture/diagrams/service-boundaries.md
+
 ## License
 
 Proprietary / internal (adjust as needed). Add explicit license if distribution scope changes.

--- a/README.md
+++ b/README.md
@@ -205,6 +205,53 @@ All prior architecture rationale, migration notes, and phase achievements remain
  - Component: API — docs/architecture/diagrams/component-api.md
  - Component: Simulator — docs/architecture/diagrams/component-simulator.md
 
+### Architecture Overview (inline)
+
+```mermaid
+flowchart LR
+  %% External actors and sources
+  subgraph External
+    SP["SharePoint (CSV exports)"]
+    Operator["Operator / API Client"]
+  end
+
+  %% Foundation components
+  subgraph Foundation
+    direction LR
+    Collector[["Collector\n(move + stage + archive)"]]
+    Staging[("Staging Dir")]
+    Archive[("Archive Dir")]
+
+    Loader[["Loader\n(parse CSV → rows)"]]
+    DB[("SQLite DB")]
+
+    Aggregator[["Aggregator\n(group + compute metrics)"]]
+    ExcelGen[["Excel/HTML Generator"]]
+
+    API[("FastAPI /main API/")]
+    Sim[("SharePoint CSV Simulator (/sim)")]
+  end
+
+  %% Flows
+  SP -->|CSV drops| Collector
+  Collector -->|stage| Staging
+  Collector -->|archive| Archive
+  Collector --> Loader
+  Loader --> DB
+  DB --> Aggregator
+  Aggregator --> ExcelGen
+
+  Operator -->|trigger ingest/generate| API
+  API -->|orchestrates| Collector
+  API -->|orchestrates| Aggregator
+  API -->|orchestrates| ExcelGen
+
+  %% Simulator path
+  Operator -->|generate sample data| Sim
+  Sim -->|write CSVs| Staging
+  Staging -.-> |picked up by| Collector
+```
+
 ## License
 
 Proprietary / internal (adjust as needed). Add explicit license if distribution scope changes.

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![Quality Gate](https://github.com/jwardwell7077/charlie-reporting/actions/workflows/quality-gate.yml/badge.svg)](https://github.com/jwardwell7077/charlie-reporting/actions/workflows/quality-gate.yml)
 
-This repository has been reset to a **minimal, configurable reporting foundation** focused on:
+This repository is a minimal, configurable reporting foundation focused on:
 
 * Ingesting SharePoint‑exported CSV drops
 * Loading data into a lightweight local SQLite store
 * Generating hourly and quad‑daily Excel/HTML outputs
-* Preparing for later email distribution & real SharePoint / Graph API integration
+* Preparing for later email distribution and Graph API integration
 
-Historic microservice code has been pruned (kept in prior Git history). Documentation & configuration files remain for reference/value.
+Historic microservice code was pruned (kept in prior Git history). Documentation and configuration files remain for reference/value.
 
 ## Current Core
 
@@ -30,8 +30,6 @@ data/ (sample CSVs kept)
 docs/ (original documentation preserved)
 ```
 
-* Lightweight SharePoint CSV simulator (deterministic test data generator) under `sharepoint_sim` with FastAPI endpoints mounted at `/sim`:
-
 ## SharePoint CSV Simulator Testing
 
 All dataset generators are covered by property-based tests (using Hypothesis) that verify:
@@ -45,7 +43,7 @@ Edge-case and regression tests are included for all error branches and invariant
 
 ## SharePoint CSV Simulator Usage
 
-The simulator is mounted at `/sim` in the main API. Example endpoints:
+Simulator is mounted at `/sim` in the main API. Example endpoints:
 
 * `POST /sim/generate?types=ACQ,Productivity&rows=25` — generate one or more datasets
 * `GET /sim/files` — list generated files
@@ -65,7 +63,7 @@ Files are named `<DATASET>__YYYY-MM-DD_HHMM.csv` (5‑minute UTC rounding) and r
 
 ## Configuration Overview
 
-Active runtime configuration now lives in `config/settings.toml` (see populated example in repo). Key sections:
+Active runtime configuration lives in `config/settings.toml` (see populated example). Key sections:
 
 * `[schedules]` – hourly interval + explicit quad‑daily times
 * `[data_sources]` / `[[data_sources.sources]]` – list of named CSV patterns to ingest
@@ -73,7 +71,7 @@ Active runtime configuration now lives in `config/settings.toml` (see populated 
 * `[report]` – output directory, workbook name, per‑source column whitelists
 * `[email]` – (placeholder) future outbound email metadata
 
-Legacy `config/config.toml` provided email folder filters & per‑file column selections. These have been **mapped forward**:
+Legacy `config/config.toml` folder filters and per‑file column selections are mapped forward:
 
 | Legacy Section | New Mapping |
 |----------------|-------------|
@@ -81,49 +79,6 @@ Legacy `config/config.toml` provided email folder filters & per‑file column se
 | `output.excel_dir` | `report.output_dir` |
 | `output.archive_dir` | `collector.archive_dir` |
 | `directory_scan.scan_path` | `collector.input_root` |
-
-````markdown
-# Charlie Reporting (Lean Foundation Restart)
-
-This repository has been reset to a **minimal, configurable reporting foundation** focused on:
-
-* Ingesting SharePoint‑exported CSV drops
-* Loading data into a lightweight local SQLite store
-* Generating hourly and quad‑daily Excel/HTML outputs
-* Preparing for later email distribution & real SharePoint / Graph API integration
-
-Historic microservice code has been pruned (kept in prior Git history). Documentation & configuration files remain for reference/value.
-
-## Branch Strategy
-
-`main-foundation` is the active stabilized branch while foundational refactors settle. Treat it as the integration target (temporary stand‑in for `main`). Merge forward into real `main` once scale/production concerns resume.
-
-## Current Core
-
-```text
-foundation/
- README.md              # Detailed foundation architecture
- pyproject.toml         # Tooling + deps
- src/
-  config/settings.py   # TOML settings loader
-  pipeline/            # collector | loader | aggregator | excel
-  services/            # sharepoint_stub.py | api.py
-  core/                # hashing, run tracking utilities
- tests/                # characterization + settings tests
-config/
- settings.toml          # Active foundation configuration
- config.toml            # Legacy (phase 2) config retained
-data/                   # Sample CSVs
-docs/                   # Architecture, migration, phase planning
-```
-
-## Configuration Overview
-
-Active runtime configuration now lives in `config/settings.toml`.
-
-Key sections: `[schedules]`, `[data_sources]` / `[[data_sources.sources]]`, `[collector]`, `[report]`, `[email]` (placeholder).
-
-Legacy to new mapping (selected): `output.excel_dir` → `report.output_dir`, `directory_scan.scan_path` → `collector.input_root`, attachment filename columns → `report.columns`.
 
 ## Quick Start
 
@@ -144,11 +99,12 @@ curl -X POST http://localhost:8000/ingest
 curl -X POST http://localhost:8000/generate/hourly
 ```
 
-## Quality Gate & Tooling
+## Quality Gate and Tooling
 
-Strict gate (local & CI): Ruff (lint/format), mypy (strict), Pyright (strict), pydoclint, interrogate (100% doc coverage), pytest (100% line coverage enforced). Test files are now included in Ruff, mypy, and Pyright runs to keep helper code quality aligned with production modules.
+Strict gate (local & CI): Ruff (lint/format), mypy (strict), Pyright (strict), pydoclint, interrogate (100% doc coverage), pytest (100% line coverage enforced). Test files are included in Ruff, mypy, and Pyright runs.
 
 Run locally:
+
 ```bash
 scripts/quality_gate.sh
 ```
@@ -157,60 +113,37 @@ Pre-commit (`pre-commit install`) runs Ruff, mypy subset, Pyright, quick pytest 
 
 ## CI
 
-Workflow `.github/workflows/quality-gate.yml` enforces the gate on pushes / PRs to `main` & `main-foundation`.
+Workflow `.github/workflows/quality-gate.yml` enforces the gate on pushes/PRs to `main` and `main-foundation`.
 
 ## Development Principles
 
-We adhere to a core design principle: **Minimal Entry / Minimal Exit**.
+We adhere to a core design principle: Minimal Entry / Minimal Exit.
 
 > Each component exposes the fewest necessary public entry points and leaves every object or return value in a fully validated, deterministic state immediately upon exit—no redundant wrapper layers or deferred hidden side effects.
 
-Practical examples:
+Examples:
+
 * `Roster` self-loads on construction (optional `from_csv` classmethod) — removed former `load_roster()` wrapper.
-* Dataset generators expose a single `build()` path instead of scattered helper functions.
+* Dataset generators expose a single `build()` path instead of scattered helpers.
 * Service orchestration keeps state explicit (roster, RNG, storage) with no hidden globals.
-
-See `docs/development_principles.md` for rationale, review checklist, and contribution guidelines.
-
-## Baseline Tag
-
-Tag the stabilized foundation:
-```bash
-git checkout main-foundation
-git tag -a v0.2.0-foundation -m "Foundation quality gate baseline"
-git push origin v0.2.0-foundation
-```
-
-## Roadmap (Near Term)
-
-1. Expand tests (failure paths, loader idempotency, error cases)
-2. Add scheduler (APScheduler) hourly + quad‑daily triggers
-3. Implement email packaging (HTML inline + attachment)
-4. Extend loader (additional sources, ingestion_log semantics)
-5. Structured logging + metrics stub
-6. Replace stub with Graph API SharePoint ingestion pipeline
-
-## Contributing / Historical Docs
-
-All prior architecture rationale, migration notes, and phase achievements remain under `docs/`.
 
 ## Diagrams
 
-- [Architecture Overview (Mermaid)](docs/architecture/diagrams/architecture-overview.md)
-- [Service Boundaries (Mermaid)](docs/architecture/diagrams/service-boundaries.md)
-- [Component: Collector](docs/architecture/diagrams/component-collector.md)
-- [Component: Loader](docs/architecture/diagrams/component-loader.md)
-- [Component: Aggregator](docs/architecture/diagrams/component-aggregator.md)
-- [Component: Excel/HTML Generator](docs/architecture/diagrams/component-excel.md)
-- [Component: API](docs/architecture/diagrams/component-api.md)
-- [Component: Simulator](docs/architecture/diagrams/component-simulator.md)
+* [Architecture Overview (Mermaid)](docs/architecture/diagrams/architecture-overview.md)
+* [Service Boundaries (Mermaid)](docs/architecture/diagrams/service-boundaries.md)
+* [Component: Collector](docs/architecture/diagrams/component-collector.md)
+* [Component: Loader](docs/architecture/diagrams/component-loader.md)
+* [Component: Aggregator](docs/architecture/diagrams/component-aggregator.md)
+* [Component: Excel/HTML Generator](docs/architecture/diagrams/component-excel.md)
+* [Component: API](docs/architecture/diagrams/component-api.md)
+* [Component: Simulator](docs/architecture/diagrams/component-simulator.md)
 
 ### UML (Mermaid)
 
-- [UML Class: Foundation](docs/architecture/diagrams/uml/class-foundation.md)
-- [UML Sequence: Ingest Flow](docs/architecture/diagrams/uml/sequence-ingest.md)
-- [UML Sequence: Generate Hourly Report](docs/architecture/diagrams/uml/sequence-generate-hourly.md)
-- [UML Sequence: Simulator Generate](docs/architecture/diagrams/uml/sequence-simulator-generate.md)
+* [UML Class: Foundation](docs/architecture/diagrams/uml/class-foundation.md)
+* [UML Sequence: Ingest Flow](docs/architecture/diagrams/uml/sequence-ingest.md)
+* [UML Sequence: Generate Hourly Report](docs/architecture/diagrams/uml/sequence-generate-hourly.md)
+* [UML Sequence: Simulator Generate](docs/architecture/diagrams/uml/sequence-simulator-generate.md)
 
 ### Architecture Overview (inline)
 
@@ -261,9 +194,7 @@ flowchart LR
 
 ## License
 
-Proprietary / internal (adjust as needed). Add explicit license if distribution scope changes.
+Proprietary/internal (adjust as needed). Add explicit license if distribution scope changes.
 
 ---
 For deeper architectural description see `foundation/README.md`.
-
-````

--- a/docs/architecture/diagrams/architecture-overview.md
+++ b/docs/architecture/diagrams/architecture-overview.md
@@ -52,4 +52,3 @@ Legend:
 - External systems on the left; internal components grouped as “Foundation.”
 - The API exposes endpoints to generate sample CSVs (via the simulator), trigger ingest, and produce reports.
 - The collector moves files from the input root into staging and archive, then the loader parses for storage; aggregation and report generation follow.
-

--- a/docs/architecture/diagrams/architecture-overview.md
+++ b/docs/architecture/diagrams/architecture-overview.md
@@ -1,0 +1,55 @@
+# Architecture Overview
+
+This document provides a high-level view of the foundation architecture and data flow.
+
+```mermaid
+flowchart LR
+  %% External actors and sources
+  subgraph External
+    SP["SharePoint (CSV exports)"]
+    Operator["Operator / API Client"]
+  end
+
+  %% Foundation components
+  subgraph Foundation
+    direction LR
+    Collector[["Collector\n(move + stage + archive)"]]
+    Staging[("Staging Dir")]
+    Archive[("Archive Dir")]
+
+    Loader[["Loader\n(parse CSV → rows)"]]
+    DB[("SQLite DB")]
+
+    Aggregator[["Aggregator\n(group + compute metrics)"]]
+    ExcelGen[["Excel/HTML Generator"]]
+
+    API[("FastAPI /main API/")]
+    Sim[("SharePoint CSV Simulator (/sim)")]
+  end
+
+  %% Flows
+  SP -->|CSV drops| Collector
+  Collector -->|stage| Staging
+  Collector -->|archive| Archive
+  Collector --> Loader
+  Loader --> DB
+  DB --> Aggregator
+  Aggregator --> ExcelGen
+
+  Operator -->|trigger ingest/generate| API
+  API -->|orchestrates| Collector
+  API -->|orchestrates| Aggregator
+  API -->|orchestrates| ExcelGen
+
+  %% Simulator path
+  Operator -->|generate sample data| Sim
+  Sim -->|write CSVs| Staging
+  Staging -.-> |picked up by| Collector
+```
+
+Legend:
+
+- External systems on the left; internal components grouped as “Foundation.”
+- The API exposes endpoints to generate sample CSVs (via the simulator), trigger ingest, and produce reports.
+- The collector moves files from the input root into staging and archive, then the loader parses for storage; aggregation and report generation follow.
+

--- a/docs/architecture/diagrams/component-aggregator.md
+++ b/docs/architecture/diagrams/component-aggregator.md
@@ -1,0 +1,8 @@
+# Component: Aggregator
+
+```mermaid
+flowchart TB
+  DB[(SQLite)] --> Agg[["Aggregator\n(group, aggregate, compute metrics)"]]
+  Agg --> Datasets[["Per‑source datasets\n(cleaned views)"]]
+  Agg --> KPIs[["KPIs / summaries"]]
+```

--- a/docs/architecture/diagrams/component-api.md
+++ b/docs/architecture/diagrams/component-api.md
@@ -1,0 +1,14 @@
+# Component: API (FastAPI)
+
+```mermaid
+flowchart LR
+  Client["Operator / Client"] --> API[(FastAPI)]
+
+  API -->|POST /sim/generate| Sim[(Simulator)]
+  API -->|POST /ingest| Collector[[Collector]]
+  API -->|POST /generate/hourly| Aggregator[[Aggregator]]
+  API -->|POST /generate/hourly| Excel[[Excel/HTML Generator]]
+
+  API -->|GET /sim/files| Sim
+  API -->|GET /health| Health[(Health endpoint)]
+```

--- a/docs/architecture/diagrams/component-collector.md
+++ b/docs/architecture/diagrams/component-collector.md
@@ -1,0 +1,23 @@
+# Component: Collector
+
+```mermaid
+flowchart LR
+  subgraph Sources
+    SP["SharePoint CSV drops"]
+    SIM["Simulator output (/sim)"]
+  end
+
+  InputRoot[("collector.input_root")]
+  Staging[("collector.staging_dir")]
+  Archive[("collector.archive_dir")]
+
+  Collector[["Collector\n(discover + move + archive)"]]
+  Loader[["Loader"]]
+
+  SP -->|files| InputRoot
+  SIM -->|files| InputRoot
+  InputRoot -->|scan| Collector
+  Collector -->|move staged| Staging
+  Collector -->|archive originals| Archive
+  Collector -->|trigger/process| Loader
+```

--- a/docs/architecture/diagrams/component-excel.md
+++ b/docs/architecture/diagrams/component-excel.md
@@ -1,0 +1,8 @@
+# Component: Excel / HTML Generator
+
+```mermaid
+flowchart TB
+  Agg[[Aggregated Data]] --> Excel[["Excel/HTML Generator"]]
+  Excel -->|writes| Workbook[(Workbook .xlsx)]
+  Excel -->|writes| ReportHTML[(HTML Report)]
+```

--- a/docs/architecture/diagrams/component-loader.md
+++ b/docs/architecture/diagrams/component-loader.md
@@ -1,0 +1,9 @@
+# Component: Loader
+
+```mermaid
+flowchart TB
+  Staging[(Staging Dir)] --> Loader[["Loader\n(parse CSV → rows)"]]
+  Loader --> Valid[[Validate schema & types]]
+  Valid --> DB[(SQLite)]
+  Valid -->|rejects| Rejected[(Rejected rows log)]
+```

--- a/docs/architecture/diagrams/component-simulator.md
+++ b/docs/architecture/diagrams/component-simulator.md
@@ -1,0 +1,8 @@
+# Component: SharePoint CSV Simulator
+
+```mermaid
+flowchart TB
+  Client["Operator / Client"] -->|generate types, rows| Sim[[Simulator]]
+  Sim -->|write CSV files| Output[(sharepoint_sim/)]
+  Output -->|visible to| Collector[[Collector]]
+```

--- a/docs/architecture/diagrams/service-boundaries.md
+++ b/docs/architecture/diagrams/service-boundaries.md
@@ -1,0 +1,53 @@
+# Service Boundaries
+
+This diagram outlines boundaries between core subsystems and external actors.
+
+```mermaid
+flowchart TB
+  %% External actors
+  Client["Operator / API Client"]
+  SharePoint["SharePoint (CSV source)"]
+
+  %% Bounded contexts
+  subgraph Ingestion[Ingestion]
+    direction TB
+    InCollector[[Collector]]
+    InLoader[[Loader]]
+  end
+
+  subgraph Storage[Storage]
+    DB[(SQLite)]
+  end
+
+  subgraph Reporting[Reporting]
+    Agg[[Aggregator]]
+    XGen[[Excel/HTML Generator]]
+  end
+
+  subgraph API[API Layer]
+    FastAPI[(FastAPI)]
+    Sim[(CSV Simulator)]
+  end
+
+  %% External interactions
+  Client -->|calls| FastAPI
+  SharePoint -->|drops CSV| InCollector
+
+  %% Internal flows across boundaries
+  FastAPI -->|orchestrates| InCollector
+  InCollector --> InLoader
+  InLoader --> DB
+  DB --> Agg
+  Agg --> XGen
+
+  %% Simulator boundary
+  Client -->|request sample data| Sim
+  Sim -->|writes CSVs| InCollector
+```
+
+Notes:
+
+- Each subgraph is a boundary with well-defined contracts.
+- API is the sole entry point for orchestration; no direct cross-boundary calls.
+- The simulator is optional and only writes CSVs that the ingestion boundary consumes.
+

--- a/docs/architecture/diagrams/service-boundaries.md
+++ b/docs/architecture/diagrams/service-boundaries.md
@@ -50,4 +50,3 @@ Notes:
 - Each subgraph is a boundary with well-defined contracts.
 - API is the sole entry point for orchestration; no direct cross-boundary calls.
 - The simulator is optional and only writes CSVs that the ingestion boundary consumes.
-

--- a/docs/architecture/diagrams/uml/class-foundation.md
+++ b/docs/architecture/diagrams/uml/class-foundation.md
@@ -1,0 +1,47 @@
+# UML Class Diagram: Foundation (conceptual)
+
+```mermaid
+classDiagram
+  class Api {
+    +post_ingest()
+    +post_generate_hourly()
+    +get_health()
+  }
+
+  class Collector {
+    +scan()
+    +stage(file)
+    +archive(file)
+  }
+
+  class Loader {
+    +parse(csv_path)
+    +validate(row)
+    +persist(rows)
+  }
+
+  class Aggregator {
+    +build_views()
+    +compute_kpis()
+  }
+
+  class ExcelGenerator {
+    +write_workbook(datasets)
+    +write_html(datasets)
+  }
+
+  class SQLiteDB {
+    +connect()
+    +insert(table, rows)
+    +query(sql)
+  }
+
+  Api --> Collector : orchestrates
+  Api --> Aggregator : orchestrates
+  Api --> ExcelGenerator : orchestrates
+
+  Collector --> Loader : triggers
+  Loader --> SQLiteDB : persists to
+  Aggregator --> SQLiteDB : reads from
+  ExcelGenerator --> Aggregator : consumes datasets
+```

--- a/docs/architecture/diagrams/uml/sequence-generate-hourly.md
+++ b/docs/architecture/diagrams/uml/sequence-generate-hourly.md
@@ -1,0 +1,19 @@
+# UML Sequence Diagram: Generate Hourly Report
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant C as Client
+  participant API as FastAPI
+  participant AGG as Aggregator
+  participant X as ExcelGenerator
+  participant DB as SQLite
+
+  C->>API: POST /generate/hourly
+  API->>AGG: build_views()
+  AGG->>DB: query()
+  AGG-->>API: datasets
+  API->>X: write_workbook(datasets)
+  X-->>API: workbook path
+  API-->>C: 200 OK + locations
+```

--- a/docs/architecture/diagrams/uml/sequence-ingest.md
+++ b/docs/architecture/diagrams/uml/sequence-ingest.md
@@ -1,0 +1,19 @@
+# UML Sequence Diagram: Ingest Flow
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant C as Client
+  participant API as FastAPI
+  participant COL as Collector
+  participant L as Loader
+  participant DB as SQLite
+
+  C->>API: POST /ingest
+  API->>COL: scan()
+  COL->>COL: move to staging + archive
+  COL->>L: process(staged files)
+  L->>L: parse & validate
+  L->>DB: persist(rows)
+  API-->>C: 202 Accepted / 200 OK
+```

--- a/docs/architecture/diagrams/uml/sequence-simulator-generate.md
+++ b/docs/architecture/diagrams/uml/sequence-simulator-generate.md
@@ -1,0 +1,18 @@
+# UML Sequence Diagram: Simulator Generate
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant C as Client
+  participant API as FastAPI
+  participant SIM as Simulator
+  participant FS as sharepoint_sim/
+  participant COL as Collector
+
+  C->>API: POST /sim/generate?types=...
+  API->>SIM: generate(types, rows)
+  SIM->>FS: write CSV files
+  FS-->>COL: files visible for scan
+  C->>API: POST /ingest
+  API->>COL: scan() + process
+```


### PR DESCRIPTION
Adds Mermaid diagrams (architecture overview, service boundaries, per-component) and Mermaid UML (class + sequences). Updates README with clickable links and inline main diagram. Ready to merge to main.